### PR TITLE
fix: remove forEach

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,10 @@ function recursiveFilterObject(properties, propertyToFilter) {
     return propertyToFilterCopy.length ? { [currentPropertyToFilter]: parsedProperties } : parsedProperties
 }
 
-async function processEvent(event, { global, storage }) {
+async function processEvent(event, { global }) {
     let propertiesCopy = event.properties ? { ...event.properties } : {}
 
-    global.propertiesToFilter.forEach(async function (propertyToFilter) {
+    for (const propertyToFilter of global.propertiesToFilter) {
         if (propertyToFilter === '$ip') {
             delete event.ip
         }
@@ -33,8 +33,8 @@ async function processEvent(event, { global, storage }) {
         } else if (propertyToFilter in propertiesCopy) {
             delete propertiesCopy[propertyToFilter]
         }
-    })
-
+    }
+    
     return { ...event, properties: propertiesCopy }
 }
 


### PR DESCRIPTION
I think the `forEach` with the async function is potentially causing issues where different versions of the properties object are being passed to `recursiveFilterObject`, causing it to misbehave. 

A user has reported that the plugin isn't filtering nested properties inside `$set` correctly so this might be the cause