### PR TITLE
Fix props being empty when nested field not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ function recursiveFilterObject(properties, propertyToFilter) {
     } else if (currentPropertyToFilter in properties) {
         parsedProperties = { ...properties }
         delete parsedProperties[currentPropertyToFilter]
+    } else {
+        parsedProperties = { ...properties }
     }
 
     return propertyToFilterCopy.length ? { [currentPropertyToFilter]: parsedProperties } : parsedProperties

--- a/index.test.js
+++ b/index.test.js
@@ -1,7 +1,7 @@
 const { createEvent } = require('@posthog/plugin-scaffold/test/utils')
 const { processEvent } = require('.')
 
-const global = { propertiesToFilter: ['gender', '$set.age', 'foo.bar.baz.one', 'nonExisting'] }
+const global = { propertiesToFilter: ['gender', '$set.age', 'foo.bar.baz.one', 'nonExisting', '$set.$not_in_props'] }
 
 const properties = {
     properties: {


### PR DESCRIPTION
I discovered that when a filter is passed that doesn't match a property, the entire set of properties becomes an empty object `{}`.

I've been running into an issue with filtering nested properties, I don't know that this would fix my issue but it still seems like it could be a bug.