### PR TITLE
Skip recursiveFilter method when no properties are given

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ async function processEvent(event, { global }) {
             delete event.ip
         }
 
-        if (propertyToFilter.includes('.')) {
+        if (Object.keys(propertiesCopy).length > 0 && propertyToFilter.includes('.')) {
             propertiesCopy = {
                 ...propertiesCopy,
                 ...recursiveFilterObject(propertiesCopy, propertyToFilter.split('.')),

--- a/index.test.js
+++ b/index.test.js
@@ -34,3 +34,12 @@ test('event properties are filtered', async () => {
     expect(event.properties.$set).toHaveProperty('firstName', 'Post')
     expect(event.properties.foo.bar.baz).toHaveProperty('two', 'two')
 })
+
+const emptyProperties = {}
+
+test('event properties are empty when no properties are given', async () => {
+    const event = await processEvent(createEvent(emptyProperties), { global })
+
+    expect(event.properties).not.toHaveProperty('$set')
+    expect(event.properties).not.toHaveProperty('foo')
+})


### PR DESCRIPTION
This fixes a bug that https://github.com/witty-works/posthog-property-filter-plugin/pull/6 introduced. If `propertiesCopy` is empty, it seems like it shouldn't have to go through the recursiveFilterObject. 

I was noticing that my posthog event which was getting weird properties didn't actually have any properties passed to it from our code. So I ran the tests with empty properties and noticed it's adding the keys `$set` and `foo`. The easy fix seems like to just skip the filter when there are no properties. 

But I'm not sure if that messes things up when properties are added automatically from https://github.com/PostHog/posthog-plugin-geoip. 