### PR TITLE
Draft: filter $set and $set_once at the top level

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,28 @@ function recursiveFilterObject(properties, propertyToFilter) {
 async function processEvent(event, { global }) {
     let propertiesCopy = event.properties ? { ...event.properties } : {}
 
+    // filter items from top level $set
+    const setPropsToFilter = global.propertiesToFilter.filter(prop => prop.includes('$set'))
+    if (event.$set && setPropsToFilter.length > 0) {
+        let setPropCopy = {...event.$set }
+        for (const propertyToFilter of setPropsToFilter) {
+            let propKeyToFilter = propertyToFilter.split('.').pop()
+            delete setPropCopy[propKeyToFilter]
+        }
+        event.$set = setPropCopy
+    }
+
+    // filter items from top level $set_once
+    const setOncePropsToFilter = global.propertiesToFilter.filter(prop => prop.includes('$set_once'))
+    if (event.$set_once && setOncePropsToFilter.length > 0) {
+        let setOncePropCopy = {...event.$set_once }
+        for (const propertyToFilter of setOncePropsToFilter) {
+            let propKeyToFilter = propertyToFilter.split('.').pop()
+            delete setOncePropCopy[propKeyToFilter]
+        }
+        event.$set_once = setOncePropCopy
+    }
+
     for (const propertyToFilter of global.propertiesToFilter) {
         if (propertyToFilter === '$ip') {
             delete event.ip
@@ -36,7 +58,7 @@ async function processEvent(event, { global }) {
             delete propertiesCopy[propertyToFilter]
         }
     }
-    
+
     return { ...event, properties: propertiesCopy }
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -1,7 +1,16 @@
 const { createEvent } = require('@posthog/plugin-scaffold/test/utils')
 const { processEvent } = require('.')
 
-const global = { propertiesToFilter: ['gender', '$set.age', 'foo.bar.baz.one', 'nonExisting', '$set.$not_in_props'] }
+const global = { 
+    propertiesToFilter: [
+        'gender',
+        '$set.age',
+        'foo.bar.baz.one',
+        'nonExisting',
+        '$set.$geoip_city_name',
+        '$set_once.$initial_geoip_country_name'
+    ]
+}
 
 const properties = {
     properties: {
@@ -21,6 +30,14 @@ const properties = {
             },
         },
     },
+    $set: {
+        $geoip_city_name: "Linköping",
+        $geoip_subdivision_1_name: "Östergötland County",
+    },
+    $set_once: {
+        $initial_geoip_country_name: "Sweden",
+        $initial_geoip_continent_name: "Europe",
+    }
 }
 
 test('event properties are filtered', async () => {
@@ -33,6 +50,12 @@ test('event properties are filtered', async () => {
     expect(event.properties).toHaveProperty('foo')
     expect(event.properties.$set).toHaveProperty('firstName', 'Post')
     expect(event.properties.foo.bar.baz).toHaveProperty('two', 'two')
+
+    expect(event.$set).not.toHaveProperty('$geoip_city_name')
+    expect(event.$set).toHaveProperty('$geoip_subdivision_1_name')
+
+    expect(event.$set_once).not.toHaveProperty('$initial_geoip_country_name')
+    expect(event.$set_once).toHaveProperty('$initial_geoip_continent_name')
 })
 
 const emptyProperties = {}

--- a/plugin.json
+++ b/plugin.json
@@ -14,6 +14,22 @@
       "default": "",
       "hint": "Separate properties with commas, without using spaces, like so: `foo,bar,baz`",
       "required": true
+    },
+    {
+      "key": "$set_properties",
+      "name": "List of $set properties to filter out:",
+      "type": "string",
+      "default": "",
+      "hint": "Separate properties with commas, without using spaces, like so: `foo,bar,baz`",
+      "required": true
+    },
+    {
+      "key": "$set_once_properties",
+      "name": "List of $set_once properties to filter out:",
+      "type": "string",
+      "default": "",
+      "hint": "Separate properties with commas, without using spaces, like so: `foo,bar,baz`",
+      "required": true
     }
   ]
 }


### PR DESCRIPTION
An alternate way of filtering $set and $set_once which doesn't require adding new config input fields.

Compare to https://github.com/witty-works/posthog-property-filter-plugin/pull/10