### PR TITLE
fix: don't add property values on missing top level filter part

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Important!
 
-This plugin will only work on events ingested **after** the plugin was enabled. This means it **will** register events as being the first if there were events that occured **before** it was enabled. To mitigate this, you could consider renaming the relevant events and creating an [action](https://posthog.com/docs/features/actions) that matches both the old event name and the new one.
+This plugin will only work on events ingested **after** the plugin was enabled. This means all events ingested **before** enabling this plugin will still have the properties.
 
 ## Usage
 
-This plugin will set all configured properties to null inside an ingested event. Usually it makes sense to place this plugin at the *end* of the plugin chain.
+This plugin will remove all specified properties from the event properties object.
 
 Note when specifying `$ip`, additionally `event.ip` will be removed.
 

--- a/index.js
+++ b/index.js
@@ -2,21 +2,17 @@ async function setupPlugin({ config, global }) {
     global.propertiesToFilter = config.properties.split(',')
 }
 
-function recursiveFilterObject(properties, propertyToFilter) {
-    const propertyToFilterCopy = [...propertyToFilter]
-    const currentPropertyToFilter = propertyToFilterCopy.shift()
-    let parsedProperties = {}
-
-    if (propertyToFilterCopy.length && properties[currentPropertyToFilter]) {
-        parsedProperties = recursiveFilterObject(properties[currentPropertyToFilter], propertyToFilterCopy)
-    } else if (currentPropertyToFilter in properties) {
-        parsedProperties = { ...properties }
-        delete parsedProperties[currentPropertyToFilter]
-    } else {
-        parsedProperties = { ...properties }
+function recursiveRemoveFilterObject(properties, propertyToFilterParts) {
+    // if we've reached the final filter part, then we can remove the key if it exists
+    // otherwise recursively go down the properties object with the remaining filter parts
+    const currentKey = propertyToFilterParts.shift()
+    if (currentKey != undefined && currentKey in properties) {
+        if (propertyToFilterParts.length == 0) {
+            delete properties[currentKey]
+        } else {
+            recursiveRemoveFilterObject(properties[currentKey], propertyToFilterParts)
+        }
     }
-
-    return propertyToFilterCopy.length ? { [currentPropertyToFilter]: parsedProperties } : parsedProperties
 }
 
 async function processEvent(event, { global }) {
@@ -27,14 +23,7 @@ async function processEvent(event, { global }) {
             delete event.ip
         }
 
-        if (Object.keys(propertiesCopy).length > 0 && propertyToFilter.includes('.')) {
-            propertiesCopy = {
-                ...propertiesCopy,
-                ...recursiveFilterObject(propertiesCopy, propertyToFilter.split('.')),
-            }
-        } else if (propertyToFilter in propertiesCopy) {
-            delete propertiesCopy[propertyToFilter]
-        }
+        recursiveRemoveFilterObject(propertiesCopy, propertyToFilter.split('.'))
     }
     
     return { ...event, properties: propertiesCopy }

--- a/index.test.js
+++ b/index.test.js
@@ -1,16 +1,27 @@
 const { createEvent } = require('@posthog/plugin-scaffold/test/utils')
 const { processEvent } = require('.')
 
-const global = { propertiesToFilter: ['gender', '$set.age', 'foo.bar.baz.one', 'nonExisting', '$set.$not_in_props'] }
+const global = {
+    propertiesToFilter: [
+        'gender',
+        '$set.gender',
+        '$set.age',
+        'foo.bar.baz.one',
+        'nonExisting',
+        '$set.$not_in_props',
+        'no-such.with-dot',
+]}
 
 const properties = {
     properties: {
         name: 'Mr. Hog',
         gender: 'male',
+        age: 12,
         $set: {
             age: 35,
             pet: 'dog',
             firstName: 'Post',
+            gender: 'female',
         },
         foo: {
             bar: {
@@ -33,6 +44,22 @@ test('event properties are filtered', async () => {
     expect(event.properties).toHaveProperty('foo')
     expect(event.properties.$set).toHaveProperty('firstName', 'Post')
     expect(event.properties.foo.bar.baz).toHaveProperty('two', 'two')
+    expect(event.properties).toEqual(
+    {
+        name: 'Mr. Hog',
+        age: 12,
+        $set: {
+            pet: 'dog',
+            firstName: 'Post',
+        },
+        foo: {
+            bar: {
+                baz: {
+                    two: 'two',
+                },
+            },
+        },
+    })
 })
 
 const emptyProperties = {}


### PR DESCRIPTION
If we have a filter specified e.g. `no-such.with-dot` and that property doesn't exist on the event, then the code added `no-such` to properties with all the other properties from top level. See the updated test (which fails before code changes).

I opted to rewrite the function to be simpler and just remove the properties elements rather than assigning return values.

Internal details in this thread: https://posthog.slack.com/archives/C04BU5FS2Q7/p1677181224650189?thread_ts=1676581127.246339&cid=C04BU5FS2Q7